### PR TITLE
Halt GitHub scheduled cron jobs

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,8 +1,8 @@
 name: Refresh Tournament Data
 
 on:
-  schedule:
-    - cron: '*/5 * * * *'
+  # schedule:
+  #   - cron: '*/5 * * * *'
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
GitHub cron jobs are failing (even though manual trigger works), and are unreliable, running only 3 times over 12+ hours when scheduled for every 5 minutes.